### PR TITLE
g4: nfc: use V10e nxp config, reduce loglevel

### DIFF
--- a/configs/libnfc-nxp.conf
+++ b/configs/libnfc-nxp.conf
@@ -10,12 +10,12 @@
 # ANDROID_LOG_ERROR          0x01
 # ANDROID_LOG_SILENT         0x00
 #
-NXPLOG_EXTNS_LOGLEVEL=0x03
-NXPLOG_NCIHAL_LOGLEVEL=0x03
-NXPLOG_NCIX_LOGLEVEL=0x03
-NXPLOG_NCIR_LOGLEVEL=0x03
-NXPLOG_FWDNLD_LOGLEVEL=0x03
-NXPLOG_TML_LOGLEVEL=0x03
+NXPLOG_EXTNS_LOGLEVEL=0x01
+NXPLOG_NCIHAL_LOGLEVEL=0x01
+NXPLOG_NCIX_LOGLEVEL=0x01
+NXPLOG_NCIR_LOGLEVEL=0x01
+NXPLOG_FWDNLD_LOGLEVEL=0x01
+NXPLOG_TML_LOGLEVEL=0x01
 
 ###############################################################################
 # Extension for Mifare reader enable
@@ -25,7 +25,7 @@ MIFARE_READER_ENABLE=0x01
 
 ###############################################################################
 # File location for Firmware
-FW_STORAGE="/system/vendor/firmware/libpn547_fw.so"
+FW_STORAGE="/vendor/firmware/libpn547_fw.so"
 
 ###############################################################################
 # System clock source selection configuration
@@ -74,7 +74,7 @@ NXP_RF_CONF_BLK_1={
     A0, 0D, 06, 06, 30, CF, 00, 08, 00,
     A0, 0D, 06, 06, 2F, 8F, 05, 80, 0C,
     A0, 0D, 04, 06, 03, 00, 70,
-    A0, 0D, 03, 06, 48, 18,
+    A0, 0D, 03, 06, 48, 1A,
     A0, 0D, 03, 06, 43, A0,
     A0, 0D, 06, 06, 42, 00, 00, F3, F3,
     A0, 0D, 06, 06, 41, 80, 00, 00, 00,
@@ -161,7 +161,7 @@ NXP_RF_CONF_BLK_3={
     A0, 0D, 03, 5A, 16, 00,
     A0, 0D, 03, 5A, 15, 00,
     A0, 0D, 06, 98, 2F, AF, 05, 80, 0F,
-    A0, 0D, 06, 9A, 42, 00, 00, F1, F1,
+    A0, 0D, 06, 9A, 42, 00, 00, FF, FF,
     A0, 0D, 06, 30, 44, A3, 90, 03, 00,
     A0, 0D, 06, 6C, 44, A3, 90, 03, 00,
     A0, 0D, 06, 6C, 30, CF, 00, 08, 00,
@@ -189,7 +189,7 @@ NXP_RF_CONF_BLK_4={
     A0, 0D, 06, 88, 30, 5F, 00, 16, 00,
     A0, 0D, 03, 88, 47, 00,
     A0, 0D, 06, 88, 44, A1, 90, 03, 00,
-    A0, 0D, 03, 0C, 48, 18,
+    A0, 0D, 03, 0C, 48, 1A,
     A0, 0D, 03, 10, 43, 20,
     A0, 0D, 06, 6A, 42, F8, 10, FF, FF,
     A0, 0D, 03, 6A, 16, 00,
@@ -352,3 +352,5 @@ NXP_NFC_CHIP=0x01
 NXP_SWP_RD_START_TIMEOUT=0x0A
 #Timeout in seconds
 NXP_SWP_RD_TAG_OP_TIMEOUT=0x01
+
+


### PR DESCRIPTION
Change-Id: I4a2023f4792ea66a7cd06ea272c49f782555b585